### PR TITLE
Add Readme Stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# IDE
+.idea/
+
 # Pyre type checker
 .pyre/
 

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -161,7 +161,6 @@ class ReadmeStream(GitHubStream):
     name = "readme"
     path = "/repos/{org}/{repo}/readme"
     primary_keys = ["url"]
-    # TODO what would this be? replication_key = "updated_at"
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -2,8 +2,6 @@
 
 import requests
 from typing import Any, Dict, Iterable, List, Optional
-
-import requests
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_github.client import GitHubStream
@@ -169,8 +167,7 @@ class ReadmeStream(GitHubStream):
     state_partitioning_keys = ["repo", "org"]
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        json = response.json()
-        yield json
+        return [response.json()]
 
     schema = th.PropertiesList(
         th.Property("type", th.StringType),

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -186,7 +186,7 @@ class ReadmeStream(GitHubStream):
         th.Property("download_url", th.StringType),
         th.Property(
             "_links",
-            th.PropertiesList(
+            th.ObjectType(
                 th.Property("git", th.StringType),
                 th.Property("self", th.StringType),
                 th.Property("html", th.StringType),

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -18,7 +18,7 @@ class RepositoryStream(GitHubStream):
     name = "repositories"
 
     def get_url_params(
-            self, context: Optional[dict], next_page_token: Optional[Any]
+        self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         assert context is not None, f"Context cannot be empty for '{self.name}' stream."
@@ -118,11 +118,14 @@ class ReadmeStream(GitHubStream):
         th.Property("git_url", th.StringType),
         th.Property("html_url", th.StringType),
         th.Property("download_url", th.StringType),
-        th.Property("_links", th.PropertiesList(
-            th.Property("git", th.StringType),
-            th.Property("self", th.StringType),
-            th.Property("html", th.StringType),
-        )),
+        th.Property(
+            "_links",
+            th.PropertiesList(
+                th.Property("git", th.StringType),
+                th.Property("self", th.StringType),
+                th.Property("html", th.StringType),
+            ),
+        ),
     ).to_dict()
 
 
@@ -201,7 +204,7 @@ class IssueCommentsStream(GitHubStream):
         return super().get_records(context)
 
     def get_url_params(
-            self, context: Optional[dict], next_page_token: Optional[Any]
+        self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -160,7 +160,7 @@ class RepositoryStream(GitHubStream):
 class ReadmeStream(GitHubStream):
     name = "readme"
     path = "/repos/{org}/{repo}/readme"
-    primary_keys = ["url"]
+    primary_keys = ["repo", "org"]
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
@@ -169,6 +169,10 @@ class ReadmeStream(GitHubStream):
         return [response.json()]
 
     schema = th.PropertiesList(
+        # Parent Keys
+        th.Property("repo", th.StringType),
+        th.Property("org", th.StringType),
+        # README Keys
         th.Property("type", th.StringType),
         th.Property("encoding", th.StringType),
         th.Property("size", th.IntegerType),

--- a/tap_github/tap.py
+++ b/tap_github/tap.py
@@ -5,7 +5,12 @@ from typing import List
 from singer_sdk import Tap, Stream
 from singer_sdk import typing as th  # JSON schema typing helpers
 
-from tap_github.streams import RepositoryStream, IssuesStream, IssueCommentsStream, ReadmeStream
+from tap_github.streams import (
+    RepositoryStream,
+    IssuesStream,
+    IssueCommentsStream,
+    ReadmeStream,
+)
 
 
 class TapGitHub(Tap):

--- a/tap_github/tap.py
+++ b/tap_github/tap.py
@@ -5,7 +5,7 @@ from typing import List
 from singer_sdk import Tap, Stream
 from singer_sdk import typing as th  # JSON schema typing helpers
 
-from tap_github.streams import RepositoryStream, IssuesStream, IssueCommentsStream
+from tap_github.streams import RepositoryStream, IssuesStream, IssueCommentsStream, ReadmeStream
 
 
 class TapGitHub(Tap):
@@ -38,6 +38,7 @@ class TapGitHub(Tap):
             RepositoryStream(tap=self),
             IssuesStream(tap=self),
             IssueCommentsStream(tap=self),
+            ReadmeStream(tap=self),
         ]
 
 


### PR DESCRIPTION
An attempt at adding the README stream.
A few questions
- What do I do for the replication key and primary key?
- Is it ok to just return the json given for the parse_response? We aren't getting a list or anything, so I think it's fine here.
- poetry isn't making a .venv, and is instead storing it somewhere in my user app data. Is this special for this project? 
![image](https://user-images.githubusercontent.com/25571542/132993374-b2a0350e-5ee2-42c8-8623-eb5834366eba.png)
Just a little confused since the oviohub repo adds it as a .venv, and having different behaviour here is confusing me haha
