### PR TITLE
Mitigate GitHub API not having "since" parameter for /pulls (#88)

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -23,6 +23,12 @@ class GitHubRestStream(RESTStream):
     DEFAULT_API_BASE_URL = "https://api.github.com"
     LOG_REQUEST_METRIC_URLS = True
 
+    # GitHub is missing the "since" parameter on a few endpoints
+    # set this parameter to True if your stream needs to navigate data in descending order
+    # and try to exit early on its own.
+    # This only has effect on streams whose `replication_key` is `updated_at`.
+    missing_since_parameter = False
+
     _authenticator: Optional[GitHubTokenAuthenticator] = None
 
     @property
@@ -65,8 +71,6 @@ class GitHubRestStream(RESTStream):
         if "next" not in response.links.keys():
             return None
 
-        # Unfortunately the /starred, /stargazers and /events endpoints do not support
-        # the "since" parameter out of the box. So we use a workaround here to exit early.
         resp_json = response.json()
         if isinstance(resp_json, list):
             results = resp_json
@@ -77,11 +81,27 @@ class GitHubRestStream(RESTStream):
         if not results:
             return None
 
-        if self.replication_key in ["starred_at", "created_at"]:
-            parsed_request_url = urlparse(response.request.url)
-            since = parse_qs(str(parsed_request_url.query))["since"][0]
-            if since and (parse(results[-1][self.replication_key]) < parse(since)):
-                return None
+        # Unfortunately endpoints such as /starred, /stargazers, /events and /pulls do not support
+        # the "since" parameter out of the box. So we use a workaround here to exit early.
+        # For such streams, we sort by descending dates (most recent first), and paginate
+        # "back in time" until we reach records before our "since" parameter.
+        request_parameters = parse_qs(str(urlparse(response.request.url).query))
+        since = (
+            request_parameters["since"][0] if "since" in request_parameters else None
+        )
+        direction = (
+            request_parameters["direction"][0]
+            if "direction" in request_parameters
+            else None
+        )
+        if (
+            # commit_timestamp is a constructed key which does not exist in the raw response
+            self.replication_key != "commit_timestamp"
+            and since
+            and direction == "desc"
+            and (parse(results[-1][self.replication_key]) < parse(since))
+        ):
+            return None
 
         # Use header links returned by the GitHub API.
         parsed_url = urlparse(response.links["next"]["url"])
@@ -104,19 +124,23 @@ class GitHubRestStream(RESTStream):
 
         if self.replication_key == "updated_at":
             params["sort"] = "updated"
-            params["direction"] = "asc"
-        elif self.replication_key == "starred_at":
+            params["direction"] = "desc" if self.missing_since_parameter else "asc"
+
+        # Unfortunately the /starred, /stargazers (starred_at) and /events (created_at) endpoints do not support
+        # the "since" parameter out of the box. But we use a workaround in 'get_next_page_token'.
+        elif self.replication_key in ["starred_at", "created_at"]:
             params["sort"] = "created"
             params["direction"] = "desc"
-        # By default, the API returns the data in descending order by creation / timestamp.
+
         # Warning: /commits endpoint accept "since" but results are ordered by descending commit_timestamp
-        elif self.replication_key not in ["commit_timestamp", "created_at"]:
+        elif self.replication_key == "commit_timestamp":
+            params["direction"] = "desc"
+
+        elif self.replication_key:
             self.logger.warning(
                 f"The replication key '{self.replication_key}' is not fully supported by this client yet."
             )
 
-        # Unfortunately the /starred, /stargazers (starred_at) and /events (created_at) endpoints do not support
-        # the "since" parameter out of the box. But we use a workaround in 'get_next_page_token'.
         since = self.get_starting_timestamp(context)
         if self.replication_key and since:
             params["since"] = since

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -341,6 +341,8 @@ class EventsStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     ignore_parent_replication_key = False
+    # GitHub is missing the "since" parameter on this endpoint.
+    missing_since_parameter = True
 
     def get_records(self, context: Optional[dict] = None) -> Iterable[Dict[str, Any]]:
         """Return a generator of row-type dictionary objects.
@@ -786,6 +788,8 @@ class IssueEventsStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     ignore_parent_replication_key = False
+    # GitHub is missing the "since" parameter on this endpoint.
+    missing_since_parameter = True
 
     def get_records(self, context: Optional[dict] = None) -> Iterable[Dict[str, Any]]:
         """Return a generator of row-type dictionary objects.
@@ -936,6 +940,8 @@ class PullRequestsStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
+    # GitHub is missing the "since" parameter on this endpoint.
+    missing_since_parameter = True
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -1274,6 +1280,8 @@ class StargazersStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     replication_key = "starred_at"
+    # GitHub is missing the "since" parameter on this endpoint.
+    missing_since_parameter = True
 
     @property
     def http_headers(self) -> dict:

--- a/tap_github/user_streams.py
+++ b/tap_github/user_streams.py
@@ -87,6 +87,8 @@ class StarredStream(GitHubRestStream):
     state_partitioning_keys = ["username"]
     replication_key = "starred_at"
     ignore_parent_replication_key = True
+    # GitHub is missing the "since" parameter on this endpoint.
+    missing_since_parameter = True
 
     @property
     def http_headers(self) -> dict:


### PR DESCRIPTION
Co-authored-by: Laurent Savaete <laurent@where.tf>